### PR TITLE
Fix/vacations business days logic 

### DIFF
--- a/src/validators/vacationRequestValidator.ts
+++ b/src/validators/vacationRequestValidator.ts
@@ -1,32 +1,15 @@
 import { body } from "express-validator";
 import { User } from "../models/userModel.js";
 
-/**
- * 🧩 Validaciones para crear una solicitud de vacaciones
- */
-export const createVacationRequestRules = [
-  // 🔸 requester_id (debe existir y ser válido)
-  body("requester_id")
-    .notEmpty()
-    .withMessage("El ID del solicitante es obligatorio.")
-    .isInt({ min: 1 })
-    .withMessage("El ID del solicitante debe ser un número positivo.")
-    .bail()
-    .custom(async (id) => {
-      const user = await User.findByPk(id);
-      if (!user) {
-        return Promise.reject("El usuario solicitante no existe.");
-      }
-    }),
 
-  // 🔸 start_date (formato de fecha ISO)
+export const createVacationRequestRules = [
+
   body("start_date")
     .notEmpty()
     .withMessage("La fecha de inicio es obligatoria.")
     .isISO8601()
     .withMessage("Formato de fecha inválido (usa YYYY-MM-DD)."),
 
-  // 🔸 end_date (formato y orden)
   body("end_date")
     .notEmpty()
     .withMessage("La fecha de fin es obligatoria.")
@@ -90,11 +73,6 @@ export const updateVacationRequestRules = [
       }
       return true;
     }),
-
-  body("requested_days")
-    .optional()
-    .isInt({ min: 1 })
-    .withMessage("Los días solicitados deben ser un número positivo."),
 
   body("comments")
     .optional()


### PR DESCRIPTION
## Mejoras en la lógica de cálculo de días de vacaciones

Este PR actualiza la lógica de validación y cálculo de días solicitados en las solicitudes de vacaciones.
Ahora el sistema ya no rechaza solicitudes que incluyan fines de semana o festivos, sino que:

Cuenta únicamente los días laborables (excluyendo sábados, domingos y festivos según la ubicación del usuario).

Calcula automáticamente requested_days y lo inyecta en req.body, asegurando que el cliente no pueda manipular este valor.

Permite enviar rangos amplios de fechas, pero el contador final reflejará solo los días hábiles.

Evita solicitudes inválidas:

Si el rango no contiene ningún día laborable → se devuelve un error claro.

En actualizaciones (PATCH), si solo se envía una de las dos fechas → se rechaza para evitar estados inconsistentes.

## Cambios principales

Actualización del middleware enforceBusinessDays para calcular días hábiles en lugar de bloquear rangos con días no laborables.

Ajustes en los validadores para que ya no dependan del valor de requested_days enviado por el cliente.

Se elimina cualquier requested_days del body entrante para mantener el servidor como fuente de verdad.

## Resultado

Con esta mejora, el usuario puede seleccionar cualquier rango de fechas y el sistema descontará correctamente solo los días laborables disponibles, alineándose con la lógica de vacaciones real en empresas.

![Uploading image.png…]()
